### PR TITLE
Accordion - Layout Animations

### DIFF
--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -23,6 +23,7 @@ interface IProps {
   }[];
   style?: ViewStyle;
   disableAutoClose?: boolean;
+  animate?: boolean;
 }
 
 interface IState {}
@@ -85,6 +86,7 @@ class Accordion extends React.Component<IProps, IState> {
         name={item.name}
         description={item.description}
         image={item.image}
+        animate={this.props.animate}
       />
     );
   }

--- a/src/organisms/AccordionRow.tsx
+++ b/src/organisms/AccordionRow.tsx
@@ -9,6 +9,7 @@ import {
   ImageStyle,
   TextStyle,
   ViewStyle,
+  LayoutAnimation,
 } from 'react-native';
 import theme from '../utils/Theme';
 
@@ -23,6 +24,7 @@ interface IProps {
   separatorStyle?: ViewStyle;
   onOpen?: () => void;
   onClose?: () => void;
+  animate?: boolean;
 }
 
 interface IState {
@@ -36,6 +38,9 @@ class AccordionRow extends React.Component<IProps, IState> {
   state = {isOpen: false};
 
   changeStatus(isOpen: boolean) {
+    if (this.props.animate) {
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    }
     this.setState({isOpen});
   }
 
@@ -56,7 +61,7 @@ class AccordionRow extends React.Component<IProps, IState> {
     const {isOpen} = this.state;
 
     return (
-      <View>
+      <View style={styles.root}>
         <TouchableOpacity
           onPress={() => {
             if (!isOpen === true && !!onOpen) {
@@ -98,6 +103,9 @@ class AccordionRow extends React.Component<IProps, IState> {
 export default AccordionRow;
 
 const styles = StyleSheet.create({
+  root: {
+    overflow: 'hidden',
+  },
   description: {
     marginLeft: 50,
     marginRight: 20,

--- a/stories/index.js
+++ b/stories/index.js
@@ -149,6 +149,7 @@ storiesOf('Dropdown', module)
   .add('Dropdown List', () => (
     <View style={{width: '100%'}}>
       <Accordion
+        animate
         list={[
           {name: 'Name', description: 'description', image: undefined},
           {name: 'Name2', description: 'Description2', image: undefined},


### PR DESCRIPTION
Added layout animations to Accordion. The animations are disabled by default and need to be enabled explicitly by passing `animate` prop to `<Accordion />`. The animation somehow doesn't get triggered when collapsing currently opened AccordionRow 😢 

![2](https://user-images.githubusercontent.com/13835666/76089995-0d025080-5fbb-11ea-9179-62802aa03bc3.gif)
