### PR TITLE
[for test release] safe area view fix on container for iphone 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cara-care/caramel",
   "title": "Caramel",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Cross-platform UI component library for React Native.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -36,6 +36,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "react-native-gesture-handler": "^1.6.0",
+    "react-native-safe-area-view": "1.1.1",
     "react-native-slider": "^0.11.0",
     "react-native-styled-markup": "^0.9.1"
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "react-native-gesture-handler": "^1.6.0",
+    "react-native-safe-area-context": "3.3.2",
     "react-native-safe-area-view": "1.1.1",
     "react-native-slider": "^0.11.0",
     "react-native-styled-markup": "^0.9.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cara-care/caramel",
   "title": "Caramel",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "Cross-platform UI component library for React Native.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Container.native.tsx
+++ b/src/components/Container.native.tsx
@@ -7,7 +7,7 @@ import {
   ViewStyle,
   RegisteredStyle,
 } from 'react-native';
-import {SafeAreaView} from 'react-navigation';
+import SafeAreaView from 'react-native-safe-area-view';
 
 interface Props {
   bgColor?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5454,6 +5454,11 @@ react-native-gesture-handler@^1.6.0:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
+react-native-safe-area-context@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.3.2.tgz#9549a2ce580f2374edb05e49d661258d1b8bcaed"
+  integrity sha512-yOwiiPJ1rk+/nfK13eafbpW6sKW0jOnsRem2C1LPJjM3tfTof6hlvV5eWHATye3XOpu2cJ7N+HdkUvUDGwFD2Q==
+
 react-native-safe-area-view@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-1.1.1.tgz#9833e34c384d0513f4831afcd1e54946f13897b2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5454,6 +5454,13 @@ react-native-gesture-handler@^1.6.0:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
+react-native-safe-area-view@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-1.1.1.tgz#9833e34c384d0513f4831afcd1e54946f13897b2"
+  integrity sha512-bbLCtF+tqECyPWlgkWbIwx4vDPb0GEufx/ZGcSS4UljMcrpwluachDXoW9DBxhbMCc6k1V0ccqHWN7ntbRdERQ==
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+
 react-native-safe-area-view@^0.14.9:
   version "0.14.9"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.14.9.tgz#90ee8383037010d9a5055a97cf97e4c1da1f0c3d"


### PR DESCRIPTION
Safe Area View import is changed to `react-safe-area-view` to fix safe area issue on iPhone 12.